### PR TITLE
Added license file and removed license notice from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,6 @@ Author: Joseph Ernest ([@JosephErnest](https://twitter.com/JosephErnest))
 
 Other projects: [BigPicture](http://bigpicture.bi), [bigpicture.js](https://github.com/josephernest/bigpicture.js), [AReallyBigPage](https://github.com/josephernest/AReallyBigPage), [SamplerBox](http://www.samplerbox.org), [Void](http://www.thisisvoid.org), [TalkTalkTalk](https://github.com/josephernest/TalkTalkTalk), [YellowNoiseAudio](http://www.yellownoiseaudio.com), etc.
 
-License
-----
-MIT license
-
 Dependencies
 ---
 **Writing** uses [Pagedown](https://code.google.com/archive/p/pagedown/), [Pagedown Extra](https://github.com/jmcmanus/pagedown-extra), [MathJax](https://www.mathjax.org/), StackOverflow's [editor code](https://gist.github.com/gdalgas/a652bce3a173ddc59f66), and the [Computer Modern](http://cm-unicode.sourceforge.net/) font.


### PR DESCRIPTION
I just added a license file according to [Github standarts](https://help.github.com/en/github/building-a-strong-community/adding-a-license-to-a-repository#including-an-open-source-license-in-your-repository).